### PR TITLE
Update for new SDKs

### DIFF
--- a/smallsiri/XXXRootListController.m
+++ b/smallsiri/XXXRootListController.m
@@ -14,12 +14,12 @@
 
 -(void)openGithub
 {
-	[[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://github.com/Muirey03/SmallSiri"]];
+	[[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://github.com/Muirey03/SmallSiri"] options:@{} completionHandler:nil];
 }
 
 -(void)openTwitter
 {
-	[[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://twitter.com/Muirey03"]];
+	[[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://twitter.com/Muirey03"] options:@{} completionHandler:nil];
 }
 
 @end


### PR DESCRIPTION
'openURL:' has been deprecated in iOS 10.0 - 'openURL:options:completionHandler:' should be used instead